### PR TITLE
Remove Ecto dependency

### DIFF
--- a/lib/middleware/handle_errors.ex
+++ b/lib/middleware/handle_errors.ex
@@ -17,7 +17,16 @@ defmodule DeliriumTremex.Middleware.HandleErrors do
     Enum.flat_map(errors, &format_error/1)
   end
 
-  defp format_error(%Ecto.Changeset{} = changeset) do
+  defp format_error(error) do
+    cond do
+      is_atom(error) -> format_atom_error(error)
+      is_map?(error) -> format_map_error(error)
+      is_changeset?(error) -> format_changeset_error(error)
+      true -> format_unknown_error(error)
+    end
+  end
+
+  defp format_changeset_error(changeset) do
     changeset
       |> Ecto.Changeset.traverse_errors(fn error -> error end)
       |> Enum.map(
@@ -25,11 +34,11 @@ defmodule DeliriumTremex.Middleware.HandleErrors do
       )
   end
 
-  defp format_error(error) when is_map(error) do
+  defp format_map_error(error) do
     DeliriumTremex.Formatters.Map.format(error)
   end
 
-  defp format_error(error) when is_atom(error) do
+  defp format_atom_error(error) do
     with \
       false <- is_nil(@error_builder),
       true <- Keyword.has_key?(@error_builder.__info__(:functions), error),
@@ -42,8 +51,8 @@ defmodule DeliriumTremex.Middleware.HandleErrors do
     |> DeliriumTremex.Formatters.Map.format()
   end
 
-  defp format_error(_) do
-    DeliriumTremex.Formatters.Map.format(unknown_error)
+  defp format_unknown_error(_) do
+    DeliriumTremex.Formatters.Map.format(unknown_error())
   end
 
   defp unknown_error do
@@ -52,5 +61,16 @@ defmodule DeliriumTremex.Middleware.HandleErrors do
       message: "Something went wrong",
       messages: ["Something went wrong"]
     }
+  end
+
+  defp is_changeset?(error) do
+    case Code.ensure_compiled(Ecto.Changeset) do
+      {:module, Ecto.Changeset} -> !Map.get(error, :valid?)
+      _ -> false
+    end
+  end
+
+  defp is_map?(error) do
+    is_map(error) && !Map.has_key?(error, :__struct__)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -7,6 +7,7 @@ defmodule DeliriumTremex.Mixfile do
       version: "0.1.2",
       elixir: "~> 1.5",
       start_permanent: Mix.env == :prod,
+      elixirc_paths: elixirc_paths(Mix.env),
       deps: deps()
     ]
   end
@@ -18,11 +19,12 @@ defmodule DeliriumTremex.Mixfile do
     ]
   end
 
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
       {:ex_doc, "~> 0.16"},
-      {:ecto, "~> 2.1"},
       {:gettext, "~> 0.13"},
       {:absinthe, "~> 1.4"},
       {:absinthe_plug, "~> 1.4"},

--- a/test/delirium_tremex_test.exs
+++ b/test/delirium_tremex_test.exs
@@ -11,4 +11,12 @@ defmodule DeliriumTremexTest do
     map = DeliriumTremex.Middleware.HandleErrors.call(%{errors: [:unauthorized], state: :resolved}, %{})
     assert hd(map[:errors])[:key] == :unauthorized
   end
+
+  test "format changeset error without ecto dependency as an unknown error" do
+    error_cs = %Ecto.Testset{valid?: false, changes: %{foo: "bar"}}
+
+    map = DeliriumTremex.Middleware.HandleErrors.call(%{errors: [error_cs], state: :resolved}, %{})
+
+    assert hd(map[:errors])[:key] == :unknown_error
+  end
 end

--- a/test/support/ecto_testset.ex
+++ b/test/support/ecto_testset.ex
@@ -1,0 +1,7 @@
+defmodule Ecto.Testset do
+  defstruct action: nil,
+    changes: %{},
+    errors: [],
+    data: nil,
+    valid?: false
+end

--- a/test/support/error_builder.ex
+++ b/test/support/error_builder.ex
@@ -1,0 +1,10 @@
+defmodule DeliriumTremex.ErrorBuilder do
+  def unauthorized() do
+    %{
+      code: :unauthorized,
+      key: :current_account,
+      message: "The current account is unauthorized for this action",
+      messages: ["unauthorized"]
+    }
+  end
+end


### PR DESCRIPTION
This should eliminate the need for Ecto in `mix.exs`. Pattern matching in arguments and guard clauses for `format_error/1` functions are removed and `cond` is used.

I've also added the `ErrorBuilder` module and the mock `Ecto.Testset` struct for testing purposes.